### PR TITLE
Update deprecated tokio routines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 Cargo.lock
+*rusty-tags.vi*
+*.swp
+.*.swp

--- a/tokio-chat-client/Cargo.toml
+++ b/tokio-chat-client/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "tokio-chat-client"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
+edition = "2018"
 
 [dependencies]
 cursive = "0.3.7"
-unicode-width = "0.1.4"
+unicode-width = "0.1"
 futures = "0.1"
 tokio-core = "0.1"
+tokio-codec = "0.1"
+tokio = "0.1"
 tokio-chat-common = { path = "../tokio-chat-common" }

--- a/tokio-chat-common/Cargo.toml
+++ b/tokio-chat-common/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "tokio-chat-common"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
+edition = "2018"
 
 [dependencies]
-serde = "0.8"
-serde_derive = "0.8"
-serde_json = "0.8"
-tokio-core = "0.1"
-byteorder = "1.0"
+bytes = "0.4.9"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.24"
+tokio-codec = "0.1.0"
+futures = "0.1"
+tokio = "0.1.7"
+tokio-jsoncodec = "0.1"

--- a/tokio-chat-common/src/lib.rs
+++ b/tokio-chat-common/src/lib.rs
@@ -2,19 +2,14 @@
 //!
 //! This crate should be straightforward; see tokio-chat-server for a description of the
 //! client/server protocol.
-#[macro_use]
-extern crate serde_derive;
 
-extern crate serde;
-extern crate serde_json;
-extern crate tokio_core;
-extern crate byteorder;
+use serde::{Deserialize, Serialize};
 
-mod codec;
+use tokio_jsoncodec::Codec as JsonCodec;
 
 // Handshake message sent from a client to a server when it first connects, identifying the
 // username of the client.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Handshake {
     pub name: String,
 }
@@ -25,9 +20,9 @@ impl Handshake {
     }
 }
 
-pub type HandshakeCodec = codec::LengthPrefixedJson<Handshake, Handshake>;
+pub type HandshakeCodec = JsonCodec<Handshake, Handshake>;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClientMessage(pub String);
 
 impl ClientMessage {
@@ -37,7 +32,7 @@ impl ClientMessage {
 }
 
 // Enumerate possible messages the server can send to clients.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ServerMessage {
     // A message from a client (first String) containing arbitrary content (second String).
     Message(String, String),
@@ -51,5 +46,5 @@ pub enum ServerMessage {
     UserDisconnected(String),
 }
 
-pub type ServerToClientCodec = codec::LengthPrefixedJson<ClientMessage, ServerMessage>;
-pub type ClientToServerCodec = codec::LengthPrefixedJson<ServerMessage, ClientMessage>;
+pub type ServerToClientCodec = JsonCodec<ClientMessage, ServerMessage>;
+pub type ClientToServerCodec = JsonCodec<ServerMessage, ClientMessage>;

--- a/tokio-chat-server/Cargo.toml
+++ b/tokio-chat-server/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "tokio-chat-server"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["John Gallagher <jgallagher@bignerdranch.com>"]
+edition = "2018"
 
 [dependencies]
-serde = "0.8"
-serde_derive = "0.8"
-serde_json = "0.8"
+serde = "1.0"
 futures = "0.1"
+tokio = "0.1"
+tokio-codec = "0.1"
 tokio-core = "0.1"
 byteorder = "1.0"
 tokio-chat-common = { path = "../tokio-chat-common" }


### PR DESCRIPTION
* Use tokio-jsoncodec as codec for communication between client and
server
* Update dependencies to new versions
* Update use of deprecated tokio routines and replace the current
standard
* Run cargo-fmt on files
* User Rust-2018 edition rules